### PR TITLE
Add access logs to NLB

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ module "app_nlb" {
 
   name           = "app"
   environment    = "prod"
+  logs_s3_bucket = "my-aws-logs"
 
   container_port           = "8443"
   enable_proxy_protocol_v2 = true
@@ -40,6 +41,7 @@ module "app_nlb" {
 | health\_check\_path | When using a HTTP(S) health check, the destination for the health check requests to the container. | string | `"/"` | no |
 | health\_check\_port | The port on which the container will receive health checks. | string | `"443"` | no |
 | health\_check\_protocol | The protocol that will be used for health checks.  Options are: TCP, HTTP, HTTPS | string | `"TCP"` | no |
+| logs\_s3\_bucket | S3 bucket for storing Network Load Balancer logs. | string | n/a | yes |
 | name | The service name. | string | n/a | yes |
 | nlb\_eip\_ids | List of Elastic IP allocation IDs to associate with the NLB. Requires exactly 3 IPs. | list | n/a | yes |
 | nlb\_listener\_port | The port on which the NLB will receive traffic. | string | `"443"` | no |

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@
  *
  *   name           = "app"
  *   environment    = "prod"
+ *   logs_s3_bucket = "my-aws-logs"
  *
  *   container_port           = "8443"
  *   enable_proxy_protocol_v2 = true
@@ -70,6 +71,12 @@ resource "aws_lb" "main" {
   subnet_mapping {
     subnet_id     = "${var.nlb_subnet_ids[2]}"
     allocation_id = "${var.nlb_eip_ids[2]}"
+  }
+
+  access_logs {
+    enabled = true
+    bucket  = "${var.logs_s3_bucket}"
+    prefix  = "nlb/${var.name}-${var.environment}"
   }
 
   tags = {

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,11 @@ variable "environment" {
   type        = "string"
 }
 
+variable "logs_s3_bucket" {
+  description = "S3 bucket for storing Network Load Balancer logs."
+  type        = "string"
+}
+
 variable "enable_proxy_protocol_v2" {
   description = "Boolean to enable / disable support for proxy protocol v2."
   default     = "true"


### PR DESCRIPTION
While trying to discover traffic on the NLB I noticed that there is no access logging. This adds default access logging to the NLB.