### PR TITLE
Add new variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:tf12-7552e0866ce831fb2e2459ddc1faa1017267c402
+      - image: trussworks/circleci-docker-primary:ba270cf66c7a9ae6dbc8e6190b74163ad71729d0
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,18 +12,18 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.21.0
+    rev: v0.22.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.22.0
+    rev: v1.25.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.22.2
+    rev: v1.23.6
     hooks:
       - id: golangci-lint
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module "app_nlb" {
 | health\_check\_path | When using a HTTP(S) health check, the destination for the health check requests to the container. | `string` | `"/"` | no |
 | health\_check\_port | The port on which the container will receive health checks. | `string` | `443` | no |
 | health\_check\_protocol | The protocol that will be used for health checks.  Options are: TCP, HTTP, HTTPS | `string` | `"TCP"` | no |
-| logs\_s3\_bucket | S3 bucket for storing Network Load Balancer logs. | `string` | n/a | yes |
+| logs\_s3\_bucket | S3 bucket for storing Network Load Balancer logs.  Access logs are created only if the load balancer has a TLS listener and they contain information only about TLS requests. | `string` | n/a | yes |
 | name | The service name. | `string` | n/a | yes |
 | nlb\_eip\_ids | List of Elastic IP allocation IDs to associate with the NLB. Requires exactly 3 IPs. | `list(string)` | n/a | yes |
 | nlb\_listener\_port | The port on which the NLB will receive traffic. | `string` | `"443"` | no |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Creates a Network Load Balancer (NLB) for serving an ECS backed service.
 
 Creates the following resources:
@@ -6,8 +7,7 @@ Creates the following resources:
 * TCP listener.
 * Target group for the TCP listener over the specified container port.
 
-
-## Terraform Versions
+## Terraform Version
 
 Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to master branch.
 
@@ -36,24 +36,32 @@ module "app_nlb" {
 }
 ```
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| container\_port | The port on which the container will receive traffic. | string | `"443"` | no |
-| enable\_cross\_zone\_load\_balancing | If true, cross-zone load balancing of the load balancer will be enabled. | string | `"true"` | no |
-| enable\_proxy\_protocol\_v2 | Boolean to enable / disable support for proxy protocol v2. | string | `"true"` | no |
-| environment | Environment tag, e.g prod. | string | n/a | yes |
-| health\_check\_path | When using a HTTP\(S\) health check, the destination for the health check requests to the container. | string | `"/"` | no |
-| health\_check\_port | The port on which the container will receive health checks. | string | `"443"` | no |
-| health\_check\_protocol | The protocol that will be used for health checks.  Options are: TCP, HTTP, HTTPS | string | `"TCP"` | no |
-| logs\_s3\_bucket | S3 bucket for storing Network Load Balancer logs. | string | n/a | yes |
-| name | The service name. | string | n/a | yes |
-| nlb\_eip\_ids | List of Elastic IP allocation IDs to associate with the NLB. Requires exactly 3 IPs. | list(string) | n/a | yes |
-| nlb\_listener\_port | The port on which the NLB will receive traffic. | string | `"443"` | no |
-| nlb\_subnet\_ids | Subnets IDs for the NLB. | list(string) | n/a | yes |
-| nlb\_vpc\_id | VPC ID to be used by the NLB. | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| container\_port | The port on which the container will receive traffic. | `string` | `443` | no |
+| enable\_cross\_zone\_load\_balancing | If true, cross-zone load balancing of the load balancer will be enabled. | `string` | `true` | no |
+| enable\_proxy\_protocol\_v2 | Boolean to enable / disable support for proxy protocol v2. | `string` | `"true"` | no |
+| environment | Environment tag, e.g prod. | `string` | n/a | yes |
+| health\_check\_interval | The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. Default 30 seconds. | `string` | `30` | no |
+| health\_check\_path | When using a HTTP(S) health check, the destination for the health check requests to the container. | `string` | `"/"` | no |
+| health\_check\_port | The port on which the container will receive health checks. | `string` | `443` | no |
+| health\_check\_protocol | The protocol that will be used for health checks.  Options are: TCP, HTTP, HTTPS | `string` | `"TCP"` | no |
+| health\_check\_timeout | The health check timeout. Minimum value 2 seconds, Maximum value 60 seconds. Default 5 seconds. | `string` | `5` | no |
+| logs\_s3\_bucket | S3 bucket for storing Network Load Balancer logs. | `string` | n/a | yes |
+| name | The service name. | `string` | n/a | yes |
+| nlb\_eip\_ids | List of Elastic IP allocation IDs to associate with the NLB. Requires exactly 3 IPs. | `list(string)` | n/a | yes |
+| nlb\_listener\_port | The port on which the NLB will receive traffic. | `string` | `"443"` | no |
+| nlb\_subnet\_ids | Subnets IDs for the NLB. | `list(string)` | n/a | yes |
+| nlb\_vpc\_id | VPC ID to be used by the NLB. | `string` | n/a | yes |
+| target\_group\_name | Override the default name of the NLB's target group. Must be less than or equal to 32 characters. Default: ecs-[name]-[environment]-[port]. | `string` | `""` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ module "app_nlb" {
 | health\_check\_path | When using a HTTP(S) health check, the destination for the health check requests to the container. | `string` | `"/"` | no |
 | health\_check\_port | The port on which the container will receive health checks. | `string` | `443` | no |
 | health\_check\_protocol | The protocol that will be used for health checks.  Options are: TCP, HTTP, HTTPS | `string` | `"TCP"` | no |
-| health\_check\_timeout | The health check timeout. Minimum value 2 seconds, Maximum value 60 seconds. Default 5 seconds. | `string` | `5` | no |
 | logs\_s3\_bucket | S3 bucket for storing Network Load Balancer logs. | `string` | n/a | yes |
 | name | The service name. | `string` | n/a | yes |
 | nlb\_eip\_ids | List of Elastic IP allocation IDs to associate with the NLB. Requires exactly 3 IPs. | `list(string)` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Creates the following resources:
 * TCP listener.
 * Target group for the TCP listener over the specified container port.
 
-## Terraform Version
+## Terraform Versions
 
 Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to master branch.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Creates the following resources:
 
 ## Terraform Versions
 
-Terraform 0.12. Pin module version to ~> 2.0.2. Submit pull-requests to master branch.
+Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to master branch.
 
 Terraform 0.11. Pin module version to ~> 1.5.0. Submit pull-requests to terraform011 branch.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Creates the following resources:
 
 ## Terraform Versions
 
-Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to master branch.
+Terraform 0.12. Pin module version to ~> 2.0.2. Submit pull-requests to master branch.
 
 Terraform 0.11. Pin module version to ~> 1.5.0. Submit pull-requests to terraform011 branch.
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  *
  * ## Terraform Versions
  *
- * Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to master branch.
+ * Terraform 0.12. Pin module version to ~> 2.0.2. Submit pull-requests to master branch.
  *
  * Terraform 0.11. Pin module version to ~> 1.5.0. Submit pull-requests to terraform011 branch.
  *

--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,6 @@ resource "aws_lb_target_group" "main" {
   proxy_protocol_v2 = var.enable_proxy_protocol_v2
 
   health_check {
-    timeout  = var.health_check_timeout
     interval = var.health_check_interval
     protocol = var.health_check_protocol
     port     = var.health_check_port

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,11 @@
  * * TCP listener.
  * * Target group for the TCP listener over the specified container port.
  *
+ * ## Terraform Version
+ *
+ * Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to master branch.
+ *
+ * Terraform 0.11. Pin module version to ~> 1.5.0. Submit pull-requests to terraform011 branch.
  *
  * ## Usage
  *
@@ -97,7 +102,9 @@ resource "aws_lb_listener" "main" {
 }
 
 resource "aws_lb_target_group" "main" {
-  name = "ecs-${var.name}-${var.environment}-${var.container_port}"
+  # Name must be less than or equal to 32 characters, or AWS API returns error.
+  # Error: "name" cannot be longer than 32 characters
+  name = coalesce(var.target_group_name, format("ecs-%s-%s-%s", var.name, var.environment, var.container_port))
   port = var.container_port
 
   protocol    = "TCP"
@@ -113,6 +120,8 @@ resource "aws_lb_target_group" "main" {
   proxy_protocol_v2 = var.enable_proxy_protocol_v2
 
   health_check {
+    timeout  = var.health_check_timeout
+    interval = var.health_check_interval
     protocol = var.health_check_protocol
     port     = var.health_check_port
     path     = var.health_check_protocol == "HTTP" || var.health_check_protocol == "HTTPS" ? var.health_check_path : ""
@@ -126,4 +135,3 @@ resource "aws_lb_target_group" "main" {
     Automation  = "Terraform"
   }
 }
-

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
  * * TCP listener.
  * * Target group for the TCP listener over the specified container port.
  *
- * ## Terraform Version
+ * ## Terraform Versions
  *
  * Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to master branch.
  *

--- a/main.tf
+++ b/main.tf
@@ -119,6 +119,7 @@ resource "aws_lb_target_group" "main" {
   # https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
   proxy_protocol_v2 = var.enable_proxy_protocol_v2
 
+  # Custom health check timeouts are not supported for health checks for target groups with the TCP protocols.
   health_check {
     interval = var.health_check_interval
     protocol = var.health_check_protocol

--- a/variables.tf
+++ b/variables.tf
@@ -28,12 +28,6 @@ variable "health_check_protocol" {
   type        = string
 }
 
-variable "health_check_timeout" {
-  description = "The health check timeout. Minimum value 2 seconds, Maximum value 60 seconds. Default 5 seconds."
-  type        = string
-  default     = 5
-}
-
 variable "environment" {
   description = "Environment tag, e.g prod."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -34,7 +34,7 @@ variable "environment" {
 }
 
 variable "logs_s3_bucket" {
-  description = "S3 bucket for storing Network Load Balancer logs."
+  description = "S3 bucket for storing Network Load Balancer logs.  Access logs are created only if the load balancer has a TLS listener and they contain information only about TLS requests."
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,10 +4,16 @@ variable "container_port" {
   type        = string
 }
 
-variable "health_check_protocol" {
-  description = "The protocol that will be used for health checks.  Options are: TCP, HTTP, HTTPS"
-  default     = "TCP"
+variable "health_check_interval" {
+  description = "The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. Default 30 seconds."
   type        = string
+  default     = 30
+}
+
+variable "health_check_path" {
+  description = "When using a HTTP(S) health check, the destination for the health check requests to the container."
+  type        = string
+  default     = "/"
 }
 
 variable "health_check_port" {
@@ -16,10 +22,16 @@ variable "health_check_port" {
   type        = string
 }
 
-variable "health_check_path" {
-  description = "When using a HTTP(S) health check, the destination for the health check requests to the container."
+variable "health_check_protocol" {
+  description = "The protocol that will be used for health checks.  Options are: TCP, HTTP, HTTPS"
+  default     = "TCP"
   type        = string
-  default     = "/"
+}
+
+variable "health_check_timeout" {
+  description = "The health check timeout. Minimum value 2 seconds, Maximum value 60 seconds. Default 5 seconds."
+  type        = string
+  default     = 5
 }
 
 variable "environment" {
@@ -70,3 +82,8 @@ variable "nlb_vpc_id" {
   type        = string
 }
 
+variable "target_group_name" {
+  description = "Override the default name of the NLB's target group. Must be less than or equal to 32 characters. Default: ecs-[name]-[environment]-[port]."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
This PR adds 3 new variables that were copied over from the alb terraform module.

- `target_group_name`
-  `health_check_timeout`
- `health_check_interval`.

Does not change default behavior.

Reference:

- <https://github.com/trussworks/terraform-aws-alb-web-containers>