### PR TITLE
Mdawn pin aws providers for terratests 174129036

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:e66fbea875bcb788b29b1b5f59142e8231961ec5
+  circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:8ef309ad5d975cf0763f395030ad61fe4a574158
 
 jobs:
   terratest:

--- a/README.md
+++ b/README.md
@@ -36,16 +36,23 @@ module "app_nlb" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | ~> 2.70 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.70 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | container\_port | The port on which the container will receive traffic. | `string` | `443` | no |
 | enable\_cross\_zone\_load\_balancing | If true, cross-zone load balancing of the load balancer will be enabled. | `string` | `true` | no |
 | enable\_proxy\_protocol\_v2 | Boolean to enable / disable support for proxy protocol v2. | `string` | `"true"` | no |

--- a/examples/simple/providers.tf
+++ b/examples/simple/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  version = "~> 2.70"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,8 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws = "~> 2.70"
+  }
 }


### PR DESCRIPTION
# [Pin aws providers for terratests](https://www.pivotaltracker.com/story/show/174129036)

Changes proposed in this pull request:

- Adds `providers.tf` files to terratest folders
- Pins the version for the provider in the top-level versions file
